### PR TITLE
Ajustes referencias a token de pago.

### DIFF
--- a/docs/Tokenization.md
+++ b/docs/Tokenization.md
@@ -45,6 +45,6 @@ El usuario `U`, ingresa a la aplicación (una aplicación para dispositivos móv
 
 ## Información relacionada
 
-- [Generación de un token de pago](Generate-PaymentToken.md)
+- [Generación de un token transaccional](Generate-PaymentToken.md)
 
-- [Validación de un token de pago](Redeem-PaymentToken.md)
+- [Validación de un token transaccional](Redeem-PaymentToken.md)


### PR DESCRIPTION
Correcciones que faltaron de los textos que hacen referencia a "token de pago" para reemplazar por "token transaccional".