### PR TITLE
Ajustes referencias a token de pago.

### DIFF
--- a/docs/Generate-PaymentToken.md
+++ b/docs/Generate-PaymentToken.md
@@ -51,4 +51,4 @@ ExpiresAt | datetime | Fecha y hora en formato [UTC](https://en.wikipedia.org/wi
 
 - [Proveedor de servicios de tokens (TSP)](Tokenization.md#tps)
 
-- [Validación de un token de pago](Redeem-PaymentToken.md)
+- [Validación de un token transaccional](Redeem-PaymentToken.md)


### PR DESCRIPTION
Correcciones que faltaron de los textos que hacen referencia a "token de pago" para reemplazar por "token transaccional".