### PR TITLE
Documentación de consultas de cuentas y admin de cuentas para transacciones

### DIFF
--- a/docs/Admin-CustomerTransferAccounts.md
+++ b/docs/Admin-CustomerTransferAccounts.md
@@ -1,0 +1,120 @@
+# Administrar cuentas para transferencias de un cliente
+
+Expone las operaciones que facilitan la administración de las cuentas para transferencia de fondos de un cliente.
+
+## Consultar cuentas registradas de un cliente
+
+Obtiene la información de las cuentas vinculas a un cliente para realizar transferencia de fondos.
+
+Verbo | Endpoint | Requiere autenticación
+:---: | -------- | :------------:
+GET | /app/transfers/accounts/{DocType}/{DocNumber} | [x]
+
+### Valores de la solicitud
+
+Campo | Tipo de dato | Descripción | Requerido
+:---: | :----------: | ----------- | :-------:
+{DocType} | `string` | Tipo de documento del cliente que tiene vinculadas las cuentas. Cualquier valor de la columna **Acrónimo** en la tabla de [Tipos de documento](Admin-CustomerTransferAccounts.md#attachedDocTypes). Valor esperado en la la URL sin corchetes. | [x]
+{DocNumber} | `string` | Número de documento del cliente que tiene vinculadas las cuentas. Valor esperado en la la URL sin corchetes. | [x]
+
+### Datos de la respuesta
+
+```json
+[
+  {
+    "Alias": "Cuenta-1234",
+    "CardHolderName": "Katherine R. Bortz",
+    "MaskedPan": "************1234"
+  },
+  {
+    "Alias": "Cuenta-5678",
+    "CardHolderName": "Doris J. Tadlock",
+    "MaskedPan": "************5678"
+  },
+  {
+    "Alias": "Cuenta-9101",
+    "CardHolderName": "Peggy K. Montgomery",
+    "MaskedPan": "************9101"
+  }
+]
+```
+
+<div class="admonition info">
+   <p class="first admonition-title">Información adicional</p>
+   <p class="last">Cuando el cliente no tiene cuentas registradas, la respuesta siempre será una lista vacía.</p>
+</div>
+
+### Valores de la respuesta
+
+Campo | Tipo de dato | Descripción
+:---: | :----------: | -----------
+Alias | `string` | Nombre que identifica a la cuenta.
+CardHolderName | `string` | Nombre del tarjetahabiente o titular de la cuenta.
+MaskedPan | `string` | Número enmascarado de la cuenta.
+
+## Registrar una cuenta para transferencias
+
+Vincula la información de una cuenta a la lista de cuentas registradas para transferencia de fondos de un cliente.
+
+Verbo | Endpoint | Requiere autenticación
+:---: | -------- | :------------:
+POST | /app/transfers/accounts/{DocType}/{DocNumber} | [x]
+
+Campo | Tipo de dato | Descripción | Requerido
+:---: | :----------: | ----------- | :-------:
+{DocType} | `string` | Tipo de documento del cliente al cual se vinculará la cuenta. Cualquier valor de la columna **Acrónimo** en la tabla de [Tipos de documento](Admin-CustomerTransferAccounts.md#attachedDocTypes). Valor esperado en la la URL sin corchetes. | [x]
+{DocNumber} | `string` | Número de documento del cliente al cual se vinculará la cuenta. Valor esperado en la la URL sin corchetes. | [x]
+DocType | `string` | Tipo de documento del titular asociado con la cuenta. Cualquier valor de la columna **Acrónimo** en la tabla de [Tipos de documento](Admin-CustomerTransferAccounts.md#attachedDocTypes). | [x]
+DocNumber | `string` | Número de documento del titular asociado con la cuenta. | [x]
+Alias | `string` | Nombre con el que se identificará a la cuenta. | [x]
+AccountNumber | `string` | Número de la cuenta. | [x]
+
+### Datos de la respuesta
+
+Código de estado de HTTP de acuerdo con la especificación [RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)
+
+## Eliminar una cuenta registrada
+
+Desvincula la información de una cuenta de la lista de cuentas registradas para transferencias de un cliente.
+
+Verbo | Endpoint | Requiere autenticación
+:---: | -------- | :------------:
+DELETE | /app/transfers/accounts/{DocType}/{DocNumber}/{Alias} | [x]
+
+### Valores de la solicitud
+
+Campo | Tipo de dato | Descripción | Requerido
+:---: | :----------: | ----------- | :-------:
+{DocType} | `string` | Tipo de documento del cliente que tiene vinculadas las cuentas. Cualquier valor de la columna **Acrónimo** en la tabla de [Tipos de documento](Admin-CustomerTransferAccounts.md#attachedDocTypes). Valor esperado en la la URL sin corchetes. | [x]
+{DocNumber} | `string` | Número de documento ddel cliente que tiene vinculadas las cuentas. Valor esperado en la la URL sin corchetes. | [x]
+{Alias} | `string` | Nombre con el que se identifica a la cuenta vinculada. Valor esperado en la la URL sin corchetes. | [x]
+
+### Datos de la respuesta
+
+Código de estado de HTTP de acuerdo con la especificación [RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)
+
+## Valores de respuesta más utilizados
+
+HttpStatus | Tipo de dato | Descripción
+:--------: | :----------: | -----------
+200 | `int` | La solicitud finalizó satisfactoriamente.
+404 | `int` | El cliente no existe en el sistema.
+409 | `int` | No se encuentra información de la cuenta para vincular con los datos suministrados.
+
+## Anexos
+
+### Tipos de documento
+
+<div id="attachedDocTypes"></div>
+
+Acrónimo | Descripción
+:------: | -----------
+CC | Cédula de Ciudadanía
+NIT | Número de Identificación Tributaria
+TI | Tarjeta de Identidad
+CE | Cédula de Extranjería
+PAS | Pasaporte
+
+## Información relacionada
+
+- [Solicitar un token de autenticación](JWT-Request.md)

--- a/docs/Inquiries-CustomerAccounts.md
+++ b/docs/Inquiries-CustomerAccounts.md
@@ -1,0 +1,269 @@
+# Consultas de productos financieros de un cliente
+
+Expone las operaciones de consultas transaccionales disponibles para un usuario.
+
+## Consultar productos disponibles de un cliente
+
+Obtiene la información resumida de las cuentas o productos  asociados a un usuario.
+
+Verbo | Endpoint | Requiere autenticación
+:---: | -------- | :--------------------:
+GET | /app/inquires/accounts/{DocType}/{DocNumber} | [x]
+
+### Valores de la solicitud
+
+Campo | Tipo de dato | Descripción | Requerido
+:---: | :----------: | ----------- | :-------:
+{DocType} | `string` | Tipo de documento del usuario. Cualquier valor de la columna **Acrónimo** en la tabla de [Tipos de documento](Inquiries-CustomerAccounts.md#attachedDocTypes). Valor esperado en la la URL sin corchetes. | [x]
+{DocNumber} | `string` | Número de documento del usuario. Valor esperado en la la URL sin corchetes. | [x]
+
+### Datos de la respuesta
+
+```json
+[
+  {
+    "Balance": 0,
+    "Id": "1234113",
+    "MaskedPan": "************9836",
+    "Name": "Tarjeta Multibolsillo",
+    "Order": 0,
+    "Properties": [
+      {
+        "Label": "Última transacción",
+        "Key": "LastTranName",
+        "Value": "Consulta últimos movimientos"
+      },
+      {
+        "Label": "Fecha",
+        "Key": "LastTranDate",
+        "Value": "nov 2 de 2018 a las 4:06 PM"
+      },
+      {
+        "Label": "Lugar",
+        "Key": "LastTranCardAcceptor",
+        "Value": "Almacen Compensar Movilidad"
+      }
+    ],
+    "Source": 0,
+    "SourceAccountId": null
+  }
+]
+```
+
+<div class="admonition info">
+   <p class="first admonition-title">Información adicional</p>
+   <p class="last">Cuando el cliente no existe o no tiene productos asociados, la respuesta siempre será una lista vacía.</p>
+</div>
+
+### Valores de la respuesta
+
+Campo | Tipo de dato | Descripción
+:---: | :----------: | -----------
+Balance | `decimal` | Valor del saldo actual de la cuenta.
+Id | `string` | Identificador unívoco de la cuenta.
+MaskedPan | `string` | Número enmascarado de la cuenta.
+Order | `int` | Orden del elemento para visualizar en interfaz de usuario.
+Properties | `list` | Es un conjunto de propiedades o atributos que representan información adicional de la cuenta. [Propiedades de una cuenta  ](Inquiries-CustomerAccounts.md#responseAccountProperties)
+Source | `int` | Define los sistemas reconocidos desde donde se originaron los datos de la cuenta. [Tipos de sistemas](Inquiries-CustomerAccounts.md#responseEnumSubsystems)
+SourceAccountId | `string` | Identificador de la cuenta que se utilizará en procesos transaccionales. Cuando es `null`, la cuenta no permite procesos transaccionales.
+
+#### Propiedades de una cuenta
+
+<div id="responseAccountProperties"></div>
+
+Campo | Tipo de dato | Descripción
+:---: | :----------: | -----------
+Label | `string` | Nombre o etiqueta para visualizar el contenido del atributo en interfaz de usuario.
+Key | `string` | Identificador interno del atributo.
+Value | `string` | Valor asociado con el atributo.
+
+<div class="admonition warning">
+   <p class="first admonition-title">Atención</p>
+   <p class="last">El conjunto de propiedades o atributos de una cuenta pueden variar de acuerdo con el sistema de origen del producto.</p>
+</div>
+
+#### Tipos de sistemas
+
+<div id="responseEnumSubsystems"></div>
+
+Valor | Nombre | Descripción
+:---: | :----: | -----------
+`0` | Tup | El origen de la información es del sistema **TUP**.
+`1` | Bancor | El origen de la información es del sistema **BANCOR**.
+
+## Consultar saldos de una cuenta
+
+Obtiene los saldos (balances) detallados de una cuenta cuando sistema de información administra/implementa subtipos de cuenta como los bolsillos en TUP.
+
+<div class="admonition warning">
+   <p class="first admonition-title">Atención</p>
+   <p class="last">La consulta de movimientos solo está disponible para el producto <b>Tarjeta Multibolsillo</b>, de lo contrario la respuesta siempre será una lista vacía.</p>
+</div>
+
+Verbo | Endpoint | Requiere autenticación
+:---: | -------- | :--------------------:
+GET | /app/inquires/accounts/{DocType}/{DocNumber}/{AccountId}/balances | [x]
+
+### Valores de la solicitud
+
+Campo | Tipo de dato | Descripción | Requerido
+:---: | :----------: | ----------- | :-------:
+{DocType} | `string` | Tipo de documento del usuario. Cualquier valor de la columna **Acrónimo** en la tabla de [Tipos de documento](Inquiries-CustomerAccounts.md#attachedDocTypes). Valor esperado en la la URL sin corchetes. | [x]
+{DocNumber} | `string` | Número de documento del usuario. Valor esperado en la la URL sin corchetes. | [x]
+{AccountId} | `string` | Identificador de la cuenta para la que se obtienen los saldos. Valor esperado en la la URL sin corchetes. | [x]
+
+### Datos de la respuesta
+
+```json
+[
+  {
+    "Balance": 1000,
+    "Number": "**************1280",
+    "SourceAccountId": "845698|80",
+    "TypeId": "80",
+    "TypeName": "Monedero General"
+  },
+  {
+    "Balance": 1000,
+    "Number": "**************1281",
+    "SourceAccountId": "845698|81",
+    "TypeId": "81",
+    "TypeName": "Subsidio familiar"
+  },
+  {
+    "Balance": 1000,
+    "Number": "**************1282",
+    "SourceAccountId": "845698|82",
+    "TypeId": "82",
+    "TypeName": "Subsidio Educativo"
+  },
+  {
+    "Balance": 1000,
+    "Number": "**************1283",
+    "SourceAccountId": "845698|83",
+    "TypeId": "83",
+    "TypeName": "Bonos"
+  },
+  {
+    "Balance": 1000,
+    "Number": "**************1284",
+    "SourceAccountId": "845698|84",
+    "TypeId": "84",
+    "TypeName": "Viveres General"
+  }
+]
+```
+
+<div class="admonition info">
+   <p class="first admonition-title">Información adicional</p>
+   <p class="last">Cuando la cuenta no presenta saldos, la respuesta siempre será una lista vacía.</p>
+</div>
+
+### Valores de la respuesta
+
+Campo | Tipo de dato | Descripción
+:---: | :----------: | -----------
+Balance | `decimal` | Valor del saldo actual de la cuenta.
+Number | `string` | Número enmascarado de la cuenta.
+SourceAccountId | `string` | Identificador de la cuenta que se utilizará en procesos transaccionales. Cuando es `null`, la cuenta no permite procesos transaccionales.
+TypeId | `string` | Identificador del tipo de cuenta (bolsillo) en el sistema TUP.
+TypeName | `string` | Nombre del tipo de cuenta (bolsillo) en el sistema TUP.
+
+## Consultar movimientos de una cuenta
+
+Obtiene la información de transacciones finacieras realizadas en una cuenta.
+
+Verbo | Endpoint | Requiere autenticación
+:---: | -------- | :--------------------:
+GET | /app/inquires/accounts/{DocType}/{DocNumber}/{AccountId}/{AccountTypeId?}/statements | [x]
+
+### Valores de la solicitud
+
+Campo | Tipo de dato | Descripción | Requerido
+:---: | :----------: | ----------- | :-------:
+{DocType} | `string` | Tipo de documento del usuario. Cualquier valor de la columna **Acrónimo** en la tabla de [Tipos de documento](Inquiries-CustomerAccounts.md#attachedDocTypes). Valor esperado en la la URL sin corchetes. | [x]
+{DocNumber} | `string` | Número de documento del usuario. Valor esperado en la la URL sin corchetes. | [x]
+{AccountId} | `string` | Identificador de la cuenta para la que se obtienen los saldos. Valor esperado en la la URL sin corchetes. | [x]
+{AccountTypeId?} | `string` | Identificador del tipo de cuenta. Cuando se establece, los movimientos corresponden a una cuenta (bolsillo) en el sistema TUP. Puede usar asterisco (`*`) para consultar los últimos movimientos de todo el prodcuto. Valor esperado en la la URL sin corchetes. |
+
+### Datos de la respuesta
+
+```json
+[
+  {
+    "AccountTypeId": "80",
+    "AccountTypeName": "Monedero General",
+    "Amount": 1000,
+    "CardAcceptor": "Almacen Compensar Movilidad",
+    "Category": 0,
+    "Date": "2018-11-14T17:22:15.4630000-05:00",
+    "TranName": "Transferencia",
+    "TranType": "40"
+  },
+  {
+    "AccountTypeId": "80",
+    "AccountTypeName": "Monedero General",
+    "Amount": 1000,
+    "CardAcceptor": "Almacen Compensar Movilidad",
+    "Category": 0,
+    "Date": "2018-11-14T17:22:00.8370000-05:00",
+    "TranName": "Transferencia",
+    "TranType": "40"
+  },
+  {
+    "AccountTypeId": "80",
+    "AccountTypeName": "Monedero General",
+    "Amount": 1000,
+    "CardAcceptor": "Almacen Compensar Movilidad",
+    "Category": 0,
+    "Date": "2018-11-14T17:05:58.3870000-05:00",
+    "TranName": "Transferencia",
+    "TranType": "40"
+  }
+]
+```
+
+<div class="admonition info">
+   <p class="first admonition-title">Información adicional</p>
+   <p class="last">Cuando la cuenta no presenta movimientos, la respuesta siempre será una lista vacía.</p>
+</div>
+
+### Valores de la respuesta
+
+Campo | Tipo de dato | Descripción
+:---: | :----------: | -----------
+AccountTypeId | `string` | Identificador del tipo de cuenta que afectó el movimiento/transacción.
+AccountTypeName | `string` | Nombre del tipo de cuenta que afectó el movimiento/transacción.
+Amount | `decimal` | Valor por el que se realizó el movimiento/transacción.
+CardAcceptor | `string` | Nombre del comercio donde se realizó el movimiento/transacción.
+Category | `int` | Define la naturaleza contable de la transacción finaciera. [Tipos de categoria](Inquiries-CustomerAccounts.md#responseEnumCategory)
+Date | `datetime` | Fecha y hora en que se realizó el movimiento/transacción.
+TranName | `string` | Nombre que representa el tipo de movimiento/transacción.
+TranType | `string` | Código que representa el tipo de movimiento/transacción.
+
+#### Tipos de categoria
+
+<div id="responseEnumCategory"></div>
+
+Valor | Nombre | Descripción
+:---: | :----: | -----------
+`0` | Debit | La naturaleza del débito representa un valor que fue restado de la cuenta.
+`1` | Credit | La naturaleza del crédito representa un valor a favor de la cuenta.
+
+## Anexos
+
+### Tipos de documento
+
+<div id="attachedDocTypes"></div>
+
+Acrónimo | Descripción
+:------: | -----------
+CC | Cédula de Ciudadanía
+NIT | Número de Identificación Tributaria
+TI | Tarjeta de Identidad
+CE | Cédula de Extranjería
+PAS | Pasaporte
+
+## Información relacionada
+
+- [Solicitar un token de autenticación](JWT-Request.md)

--- a/docs/Redeem-PaymentToken.md
+++ b/docs/Redeem-PaymentToken.md
@@ -14,7 +14,6 @@ PUT | /app/tokens/{Token} | [x]
 {
   "DocType": "CC",
   "DocNumber": "0000000000",
-  "ChannelKey": "ATM",
   "Metadata": "RANDOM_DATA_BY_ACQUIRER"
 }
 ```
@@ -26,7 +25,6 @@ Campo | Tipo de dato | Descripción | Requerido
 {Token} | string | Token de pago que se desea verificar. Valor en la URL sin corchetes | [x]
 DocType | string | Tipo de documento del usuario para el que se genera el token | [x]
 DocNumber | string | Número de documento del usuario para el que se genera el token | [x]
-ChannelKey | string | Cadena que identifica de manera unívoca [el canal](Get-Channels.md) para el que se generó el token | [x]
 Metadata | string | Metadatos asociados personalizados para el [TPS](Tokenization.md#tps) | [x]
 
 ## Datos de la respuesta

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,4 +15,6 @@ pages:
 - Tokenización de pagos: Tokenization.md
 - Generación de un token transaccional: Generate-PaymentToken.md
 - Validación de un token transaccional: Redeem-PaymentToken.md
-- Mensajes de respuesta: Responses.md
+- Consulta de productos de un cliente: Inquiries-CustomerAccounts.md
+- Administrar cuentas para transferencias de un cliente: Admin-CustomerTransferAccounts.md
+- Apéndice: Mensajes de respuesta: Responses.md


### PR DESCRIPTION
- Ajustes menores para remover referencias al **ChannelKey** que hicieron faltas en cambios anteriores.
- Se incluye documentación de las consultas de cuentas de un cliente y la administración de cuentas para transferencia de saldos.
- Se ajusta **YAML** para incluir en el indice los nuevos documentos.