### PR TITLE
Ajuste consulta de movimientos y mensajes de respuesta

### DIFF
--- a/docs/Inquiries-CustomerAccounts.md
+++ b/docs/Inquiries-CustomerAccounts.md
@@ -252,11 +252,8 @@ curl -X GET \
 ```json
 [
   {
-    "id": 9155726,
     "tranType": "40",
     "cardAcceptor": "Almacen San Juan",
-    "responseMessage": "Transaccion Exitosa",
-    "responseCode": "00",
     "date": "2018-11-19T11:53:57.1900000-05:00",
     "amount": 1000,
     "tranName": "Transferencia",
@@ -265,11 +262,8 @@ curl -X GET \
     "accountTypeName": "Monedero General"
   },
   {
-    "id": 9155722,
     "tranType": "40",
     "cardAcceptor": "Almacen San Juan",
-    "responseMessage": "Transaccion Exitosa",
-    "responseCode": "00",
     "date": "2018-11-19T11:53:17.6230000-05:00",
     "amount": 1000,
     "tranName": "Transferencia",
@@ -278,11 +272,8 @@ curl -X GET \
     "accountTypeName": "Monedero General"
   },
   {
-    "id": 9155659,
     "tranType": "40",
     "cardAcceptor": "Almacen San Juan",
-    "responseMessage": "Transaccion Exitosa",
-    "responseCode": "00",
     "date": "2018-11-14T17:22:15.4630000-05:00",
     "amount": 1000,
     "tranName": "Transferencia",

--- a/docs/Responses.md
+++ b/docs/Responses.md
@@ -55,7 +55,7 @@ La cabecera personalizada de respuesta `X-PRO-Response-Help` puede contener algu
 
 - StatusCode: 502
 - Reason: **Aspen** no ha podido redirigir la solicitud al sistema responsable de procesarla. Pónganse en contacto con nuestro equipo de monitoreo.
-- EventId: 15859
+- EventId: 15859, 40030, 40031, 40032
 
 ## BadRequest
 


### PR DESCRIPTION
- Se remueve del ejemplo json de la respuesta de la consulta de movimientos de una cuenta, las propiedades que ya no se incluyen desde Aspen **v.2.0.1848**

- Se agregan identificadores de eventos a la descripción del **BadGateway** en la documentación de mensajes de respuesta.